### PR TITLE
GDB-10500: Packer for building GraphDB VM images for GCP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  PACKER_VERSION: "1.11.1"
+
+jobs:
+  analyze:
+    name: Analyze the Packer scripts
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - id: clone_repository
+        name: Clone repository
+        # actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - id: setup_packer_cli
+        name: Setup Packer CLI
+        # hashicorp/setup-packer@v3.1.0
+        uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
+        with:
+          version: "${{ env.PACKER_VERSION }}"
+
+      - name: Run Packer init
+        run: packer init .
+
+      - name: Run Packer format check
+        run: packer fmt -check -recursive .
+
+      - name: Run Packer validate check
+        run: packer validate -syntax-only .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Packer Changelog
+
+All notable changes to the Packer configuration for creating GraphDB Google Cloud VM images will be documented in this file.
+
+## 1.0.0
+
+- Initial release of the Packer configuration

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@Ontotext-AD/tes

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
 # Packer for Creating GraphDB GCP VM Image
+
+[Packer](https://www.packer.io/) configuration for building [GraphDB](https://www.ontotext.com/products/graphdb/) VM images
+for [Google Cloud](https://cloud.google.com/).
+
+## About GraphDB
+
+<p style="text-align: center">
+  <a href="https://www.ontotext.com/products/graphdb/">
+    <picture>
+      <img src="https://www.ontotext.com/wp-content/uploads/2022/09/Logo-GraphDB.svg" alt="GraphDB logo" title="GraphDB" height="75">
+    </picture>
+  </a>
+</p>
+
+Ontotext GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support. With excellent enterprise features,
+integration with external search applications, compatibility with industry standards, and both community and commercial support, GraphDB is
+the preferred database choice of both small independent developers and big enterprises.
+
+## What's Included
+
+The VM image includes the following libraries and software:
+
+- GraphDB
+- GraphDB Cluster Proxy
+- OpenTelemetry
+- Google Cloud Ops Agent
+- Google Cloud CLI
+
+## Usage
+
+**1. Authentication**
+
+Before being able to run Packer, you have to authenticate your local `gcloud` CLI in Google.
+You can follow the official documentation on this here https://cloud.google.com/docs/authentication/gcloud.
+
+**2. Variables**
+
+The Packer configuration in this repository expect you to provide several required variables.
+Here's an example `variables.pkrvars.hcl` that you can extend and use:
+
+```hcl
+# Required
+project_id      = "your-google-cloud-project-id"
+build_zone      = "us-east1-b"
+graphdb_version = "10.7.0"
+
+# Optional
+image_storage_locations = ["us"]
+```
+
+You can check the rest of the variables in [variables.pkr.hcl](variables.pkr.hcl).
+
+**3. Running Packer**
+
+After preparing the variables, you can build VM images with:
+
+```shell
+packer build -var-file="variables.pkrvars.hcl" .
+```
+
+## Observability
+
+The image installs OpenTelemetry Java agent for auto instrumentation of GraphDB as well as Google's own Ops Agent for monitoring VMs.
+However, both of them are disabled by default, so to get them working you'd have to:
+
+**Enable Google Cloud Ops Agent**
+
+```shell
+systemctl enable google-cloud-ops-agent.service
+systemctl start google-cloud-ops-agent.service
+```
+
+**Instrument GraphDB**
+
+Edit `/etc/graphdb/graphdb.env` and make sure that the following lines are not commented:
+
+```properties
+JAVA_TOOL_OPTIONS="-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar"
+OTEL_RESOURCE_PROVIDERS_GCP_ENABLED="true"
+OTEL_SERVICE_NAME="GraphDB"
+OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+```
+
+Finally, you'd have to restart GraphDB with:
+
+```shell
+systemctl restart graphdb.service
+```
+
+## GraphDB Cluster Proxy
+
+By default, the VM will start only the GraphDB systemd service `graphdb.service` on port `7200`. The image has a second systemd service
+definition `graphdb_cluster_proxy.service` for a second GraphDB process in cluster proxy mode on port `7201`.
+
+This proxy is used in the clustered setup of GraphDB, see https://graphdb.ontotext.com/documentation/10.7/cluster-basics.html for more
+information.
+
+To start the cluster proxy process, use:
+
+```shell
+systemctl enable graphdb_cluster_proxy.service
+systemctl start graphdb_cluster_proxy.service
+```
+
+## Support
+
+For questions or issues related to this Packer configuration,
+please [submit an issue](https://github.com/Ontotext-AD/packer-gcp-graphdb/issues).
+
+## License
+
+This code is released under the Apache 2.0 License. See [LICENSE](LICENSE) for more details.

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -1,0 +1,27 @@
+build {
+  sources = [
+    "source.googlecompute.ubuntu_x86_64"
+  ]
+
+  provisioner "file" {
+    sources = [
+      "./files/google-cloud-ops-agent-config.yaml",
+      "./files/graphdb.env",
+      "./files/graphdb.service",
+      "./files/graphdb_cluster_proxy.env",
+      "./files/graphdb_cluster_proxy.service",
+      "./files/install_graphdb.sh"
+    ]
+    destination = "/tmp/"
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "GRAPHDB_VERSION=${var.graphdb_version}",
+      "OPEN_TELEMETRY_VERSION=${var.open_telemetry_version}"
+    ]
+
+    inline      = ["sudo -E bash /tmp/install_graphdb.sh"]
+    max_retries = var.build_max_retries
+  }
+}

--- a/files/google-cloud-ops-agent-config.yaml
+++ b/files/google-cloud-ops-agent-config.yaml
@@ -1,0 +1,17 @@
+# See https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/otlp
+combined:
+  receivers:
+    otlp:
+      type: otlp
+      grpc_endpoint: 127.0.0.1:4317
+      metrics_mode: googlecloudmonitoring
+metrics:
+  service:
+    pipelines:
+      otlp:
+        receivers: [otlp]
+traces:
+  service:
+    pipelines:
+      otlp:
+        receivers: [otlp]

--- a/files/graphdb.env
+++ b/files/graphdb.env
@@ -1,0 +1,7 @@
+GDB_JAVA_OPTS="-Dgraphdb.home=/var/opt/graphdb/node -Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true -XX:MaxRAMPercentage=85.0 -XX:-UseCompressedOops"
+
+# Uncomment to enable OpenTelemetry auto instrumentation
+#JAVA_TOOL_OPTIONS="-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar"
+#OTEL_RESOURCE_PROVIDERS_GCP_ENABLED="true"
+#OTEL_SERVICE_NAME="GraphDB"
+#OTEL_EXPORTER_OTLP_PROTOCOL="grpc"

--- a/files/graphdb.service
+++ b/files/graphdb.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="GraphDB Engine"
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+User=graphdb
+Group=graphdb
+EnvironmentFile=/etc/graphdb/graphdb.env
+ExecStart=/opt/graphdb/bin/graphdb
+TimeoutSec=120
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/files/graphdb_cluster_proxy.env
+++ b/files/graphdb_cluster_proxy.env
@@ -1,0 +1,1 @@
+GDB_JAVA_OPTS=-Dgraphdb.home=/var/opt/graphdb/cluster-proxy -Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dgraphdb.connector.port=7201 -Dhttp.socket.keepalive=true -Xmx1g

--- a/files/graphdb_cluster_proxy.service
+++ b/files/graphdb_cluster_proxy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="GraphDB Cluster Proxy"
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+User=graphdb
+Group=graphdb
+EnvironmentFile=/etc/graphdb/graphdb_cluster_proxy.env
+ExecStart="/opt/graphdb/bin/cluster-proxy"
+TimeoutSec=120
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/files/install_graphdb.sh
+++ b/files/install_graphdb.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# This script performs the following tasks:
+# * Sets the timezone to UTC.
+# * Adjusts system settings for keepalive and file max size.
+# * Disables the interactive debconf.
+# * Installs necessary tools such as bash-completion, jq, nvme-cli, openjdk-11-jdk, and unzip.
+# * Creates a system user "graphdb" for GraphDB service.
+# * Creates GraphDB directories and sets up the necessary permissions.
+# * Downloads and installs GraphDB, configuring systemd for GraphDB and GraphDB proxy.
+# * Downloads and installs Google Cloud Ops Agent.
+# * Downloads and installs OpenTelemetry Java agent.
+# * Clears the apt cache
+# * Clears authorized_keys files for security.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "##############################"
+echo "#    Begin Image Creation    #"
+echo "##############################"
+
+# --------------------------------------
+
+echo "Setting up system properties..."
+
+timedatectl set-timezone UTC
+
+echo 'net.ipv4.tcp_keepalive_time = 120' | tee -a /etc/sysctl.conf
+echo 'fs.file-max = 262144' | tee -a /etc/sysctl.conf
+
+sysctl -p
+
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# --------------------------------------
+
+echo "Waiting for outbound connectivity..."
+
+until ping -c 1 google.com &>/dev/null; do
+  echo -n "."
+  sleep 5
+done
+
+# --------------------------------------
+
+echo "Installing tools and libraries...."
+
+apt-get update -qq
+apt-get install -qq -y bash-completion jq nvme-cli openjdk-11-jdk unzip > /dev/null
+
+# --------------------------------------
+
+echo "Downloading and installing GraphDB..."
+
+useradd --comment "GraphDB Service User" --create-home --system --shell /bin/bash --user-group graphdb
+
+mkdir -p /etc/graphdb \
+         /etc/graphdb-cluster-proxy \
+         /var/opt/graphdb/node \
+         /var/opt/graphdb/cluster-proxy
+
+cd /tmp
+curl -fsSL -O https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/"${GRAPHDB_VERSION}"/graphdb-"${GRAPHDB_VERSION}"-dist.zip
+
+unzip -qq graphdb-"${GRAPHDB_VERSION}"-dist.zip
+rm graphdb-"${GRAPHDB_VERSION}"-dist.zip
+mv graphdb-"${GRAPHDB_VERSION}" /opt/graphdb-"${GRAPHDB_VERSION}"
+ln -s /opt/graphdb-"${GRAPHDB_VERSION}" /opt/graphdb
+
+mv /tmp/graphdb.env /etc/graphdb/graphdb.env
+
+chown -R graphdb:graphdb /etc/graphdb \
+                         /etc/graphdb-cluster-proxy \
+                         /opt/graphdb \
+                         /opt/graphdb-${GRAPHDB_VERSION} \
+                         /var/opt/graphdb
+
+mv /tmp/graphdb.service /lib/systemd/system/graphdb.service
+mv /tmp/graphdb_cluster_proxy.service /lib/systemd/system/graphdb_cluster_proxy.service
+
+systemctl daemon-reload
+systemctl enable graphdb.service
+
+# --------------------------------------
+
+echo "Downloading and installing Google Cloud Ops Agent..."
+
+# https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation#joint-install
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install > /dev/null 2>&1
+
+mv /tmp/google-cloud-ops-agent-config.yaml /etc/google-cloud-ops-agent/config.yaml
+chmod 644 /etc/google-cloud-ops-agent/config.yaml
+
+# Disabled by default
+systemctl disable google-cloud-ops-agent.service
+
+# --------------------------------------
+
+echo "Downloading OpenTelemetry Java agent..."
+
+mkdir -p /opt/opentelemetry/
+curl -fsSL -o /opt/opentelemetry/opentelemetry-javaagent.jar "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OPEN_TELEMETRY_VERSION}/opentelemetry-javaagent.jar"
+chmod 644 /opt/opentelemetry/opentelemetry-javaagent.jar
+
+# --------------------------------------
+
+echo "Cleaning residual files and authorized keys..."
+
+apt-get clean autoclean
+shred -u /root/.ssh/authorized_keys /home/packer/.ssh/authorized_keys || true
+
+# --------------------------------------
+
+echo "#################################"
+echo "#    Image Creation Complete    #"
+echo "#################################"

--- a/plugins.pkr.hcl
+++ b/plugins.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+  }
+}

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -1,0 +1,42 @@
+locals {
+  timestamp            = formatdate("YYYYMMDDhhmm", timestamp())
+  graphdb_image_family = format("%s-%s", var.image_family_prefix, replace(var.graphdb_version, ".", "-"))
+  graphdb_image_name   = format("%s-%s", local.graphdb_image_family, local.timestamp)
+}
+
+source "googlecompute" "ubuntu_x86_64" {
+  project_id        = var.project_id
+  skip_create_image = var.dry_run
+
+  # Source Image
+  source_image        = var.source_image
+  source_image_family = var.source_image_family
+
+  # GraphDB Image
+  image_name              = local.graphdb_image_name
+  image_family            = local.graphdb_image_family
+  image_description       = "GraphDB ${var.graphdb_version} for Google Cloud Platform"
+  image_storage_locations = var.image_storage_locations
+  image_project_id        = var.image_project_id
+  image_labels            = var.image_labels
+
+  # Build
+  instance_name = "packer-${local.graphdb_image_name}"
+  machine_type  = var.build_instance_type
+  zone          = var.build_zone
+  network       = var.build_network
+
+  tags     = var.build_network_tags
+  metadata = var.build_metadata
+
+  use_os_login = false
+
+  # Boot disk
+  disk_name = var.disk_name
+  disk_size = var.disk_size
+  disk_type = var.disk_type
+
+  # Connectivity
+  communicator = "ssh"
+  ssh_username = var.build_username
+}

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -1,0 +1,130 @@
+# Common Variables
+
+variable "project_id" {
+  description = "Identifier of the project where the VM image building will be executed."
+  type        = string
+}
+
+variable "dry_run" {
+  description = "Skip creating and publishing the VM image. Use for testing or troubleshooting."
+  type        = bool
+  default     = false
+}
+
+# GraphDB Variables
+
+variable "graphdb_version" {
+  description = "The version of GraphDB to be installed and packaged as a VM image."
+  type        = string
+}
+
+# Source Image Variables
+
+variable "source_image" {
+  description = "The source image used as the base when the packaging GraphDB VM image. Takes precedence over source_image_family."
+  type        = string
+  default     = null
+}
+
+variable "source_image_family" {
+  description = "Name of the source image family used to select the base image when packaging GraphDB. Using this will always select the latest version of the source image in the used family."
+  type        = string
+  default     = "ubuntu-2204-lts"
+}
+
+# GraphDB Image Variables
+
+variable "image_family_prefix" {
+  description = "Prefix used when naming the VM image family of the resulting GraphDB VM image."
+  type        = string
+  default     = "ontotext-graphdb"
+}
+
+variable "image_labels" {
+  description = "Labels to apply to the built GraphDB VM image."
+  type        = map(string)
+  default     = {}
+}
+
+variable "image_project_id" {
+  description = "Identifier of the project for pushing the produced GraphDB VM image. Defaults to project_id."
+  type        = string
+  default     = null
+}
+
+variable "image_storage_locations" {
+  description = "Storage location, either regional or multi-regional, where the VM image content will be stored."
+  type        = list(string)
+  default     = ["us-east1"]
+}
+
+# Build Variables
+
+variable "build_instance_type" {
+  description = "The machine type used for launching a VM instance that builds the GraphDB VM image"
+  type        = string
+  default     = "e2-standard-2"
+}
+
+variable "build_zone" {
+  description = "The zone in which to launch the VM instance used to create the GraphDB VM image."
+  type        = string
+}
+
+variable "build_network" {
+  description = "The Google Compute network ID or URL to use for the VM instance used to build the GraphDB VM image. Defaults to the default network."
+  type        = string
+  default     = null
+}
+
+variable "build_username" {
+  description = "The SSH username used for connecting to the build instance by Packer."
+  type        = string
+  default     = "packer"
+}
+
+variable "build_network_tags" {
+  description = "List of network tags to apply to the running build VM instance. Use to apply firewall rules."
+  type        = list(string)
+  default     = ["packer"]
+}
+
+variable "build_metadata" {
+  description = "Metadata key-value configurations to apply to the running build VM instance."
+  type        = map(string)
+  default     = {}
+}
+
+variable "build_max_retries" {
+  description = "Maximum amount of retries when building the GraphDB VM image."
+  type        = number
+  default     = 2
+}
+
+# Boot disk
+
+variable "disk_name" {
+  description = "Name of the boot disk for the OS in the GraphDB VM image. Defaults to the name of the launched VM instance for building the GraphDB VM image."
+  type        = string
+  default     = null
+}
+
+variable "disk_size" {
+  description = "Disk size in GBs of the boot disk for the GraphDB VM instance."
+  type        = number
+  default     = 20
+}
+
+variable "disk_type" {
+  description = "Type of the persistent disk for the GraphDB VM instance boot OS."
+  type        = string
+  default     = "pd-balanced"
+}
+
+# Open Telemetry
+
+variable "open_telemetry_version" {
+  description = "Version of the OpenTelemetry Java agent that will be installed in the GraphDB VM image."
+  type        = string
+  default     = "2.6.0"
+}


### PR DESCRIPTION
Introducing official Packer configuration for packaging GraphDB as a VM image for Google Cloud.

The Packer configurations installs the following libraries and software:

- GraphDB
- GraphDB Cluster Proxy
- OpenTelemetry
- Google Cloud Ops Agent

Added a simple CI workflow that does basic linting and formating checks.