### PR TITLE
Added variable for image_licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Packer configuration for creating GraphDB Google Cloud VM images will be documented in this file.
 
+## 1.1.0
+
+- Added `image_licenses` that will be used to associate the built VM image with Google's Marketplace VM license
+
 ## 1.0.1
 
 - Renamed `graphdb_cluster_proxy` service to `graphdb-cluster-proxy` for consistency with the rest of our VMs

--- a/source.pkr.hcl
+++ b/source.pkr.hcl
@@ -19,6 +19,7 @@ source "googlecompute" "ubuntu_x86_64" {
   image_storage_locations = var.image_storage_locations
   image_project_id        = var.image_project_id
   image_labels            = var.image_labels
+  image_licenses          = var.image_licenses
 
   # Build
   instance_name = "packer-${local.graphdb_image_name}"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -58,6 +58,12 @@ variable "image_storage_locations" {
   default     = ["us-east1"]
 }
 
+variable "image_licenses" {
+  description = "Licenses to apply to the created VM image."
+  type        = list(string)
+  default     = []
+}
+
 # Build Variables
 
 variable "build_instance_type" {


### PR DESCRIPTION
The new variable will be used to associate the built VM image with Google's Marketplace VM license